### PR TITLE
Fixed a typo in the `//+private` section.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2819,7 +2819,7 @@ Using `//+private` in a file at the package declaration will automatically add `
 package foo
 ```
 
-And `//+private file` will be equivalent to automatically adding `@(private="file")` to each declaration. This means that the remove the private-to-file association, you must apply a private-to-package attribute `@(private)` to the declaration.
+And `//+private file` will be equivalent to automatically adding `@(private="file")` to each declaration. This means that to remove the private-to-file association, you must apply a private-to-package attribute `@(private)` to the declaration.
 
 * **@(require)**
 


### PR DESCRIPTION
PS: I'm surprised that `//+` is being used as anything other than just a comment. Personally, I don't think any valid op or preprocessor directive should look like a comment, since that is confusing.