### PR TITLE
Clarified the explanation of `@(require_results)`.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2919,7 +2919,7 @@ foo :: proc() {
 
 * **@(require_results)**
 
-Ensures procedure return values are acknowledged.
+Ensures procedure return values are acknowledged, meaning that in any scope where a procedure `p` having procedure attribute `@(require_results)` is called the scope must explicitly handle the return values of procedure `p` in some way, such as by storing the return values of `p` in variables or explicitly dropping the values by setting `_` equal them.
 ```odin
 @(require_results)
 foo :: proc() -> bool {


### PR DESCRIPTION
The original text didn't make it clear what procedure attribute did at all, so I'm suggesting this clarification.