### PR TITLE
Fixed a typo and grammar in "Directives" section.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -2994,7 +2994,7 @@ Marks builtin procs in Odin's "core:runtime" package. Cannot be used in user cod
 
 ### Directives
 
-Directives a way of extending the core behaviour of the Odin programming language; have the form `#name`.
+Directives are a way of extending the core behaviour of the Odin programming language. They have the form `#directive_name`.
 
 
 #### Record Memory Layout


### PR DESCRIPTION
The semicolon usage in the original was not valid grammar.