### PR TITLE
Fixed formatting and a typo in `#packed` section.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3003,8 +3003,9 @@ Directives a way of extending the core behaviour of the Odin programming languag
 
 This tag can be applied to a struct. Removes padding between fields that's normally inserted to ensure all fields meet their type's alignment requirements. Fields remain in source order.
 
-This is useful where the structure is unlikely to be correctly aligned (the insertion rules for padding assume it **_is_**), or if the space-savings are more important or useful than the access speed of the fields.  
-Accessing a field in packed struct may require copying the field out of the struct into a temporary location, or using a machine instruction that doesn't assume the pointer address is correctly aligned, in order to be performant or avoid crashing on some systems. (See `intrinsics.unaligned_load`.)
+This is useful where the structure is unlikely to be correctly aligned (the insertion rules for padding assume it **_is_**), or if the space-savings are more important or useful than the access speed of the fields.
+
+Accessing a field in a packed struct may require copying the field out of the struct into a temporary location, or using a machine instruction that doesn't assume the pointer address is correctly aligned, in order to be performant or avoid crashing on some systems. (See `intrinsics.unaligned_load`.)
 ```odin
 struct #packed {x: u8, y: i32, z: u16, w: u8}
 ```


### PR DESCRIPTION
- Added a missing paragraph break where it was likely intended.
- Added a missing "a".