### PR TITLE
Fixed grammar of `#panic` section, etc.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3181,7 +3181,7 @@ Assert ran at compile time.
 ```
 
 * **#panic(\<string\>)**
-Panic ran at compile time. Equivalent to an `#assert` with a `false` condition.
+Panic runs at compile-time. It is functionally equivalent to an `#assert` with a `false` condition, but `#panic` has an error message string parameter.
 ```odin
 #panic(SOME_message_CONDITION)
 ```


### PR DESCRIPTION
I also added some clarification and made the claim more precise.