### PR TITLE
Corrected erroneous argument name for `#panic`.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3183,7 +3183,7 @@ Assert ran at compile time.
 * **#panic(\<string\>)**
 Panic ran at compile time. Equivalent to an `#assert` with a `false` condition.
 ```odin
-#panic(SOME_message_CONDITION)
+#panic(message)
 ```
 
 * **#config(\<identifer\>, default)**


### PR DESCRIPTION
Previously, the argument given was `SOME_message_CONDITION`, which doesn't make logic sense given that `#panic` doesn't accept any condition but instead only takes a string.