### PR TITLE
Added hyphens near "Adv. Idioms" for clarity.

### DIFF
--- a/content/docs/overview.md
+++ b/content/docs/overview.md
@@ -3242,7 +3242,7 @@ hash :: #load_hash("path/to/file", "crc32")
 
 ### Advanced idioms
 
-Subtype polymorphism with runtime type safe down casting:
+Subtype polymorphism with run-time type-safe down-casting:
 ```odin
 Entity :: struct {
 	id:   u64,


### PR DESCRIPTION
- In previous parts of the document, "run-time" was used instead of "runtime". Which spelling to choose is subjective, but one should be consistent.
- More importantly though, I added hyphens to "type safe" and "down casting" to improve readability and clarify word associations.