### PR TITLE
Updated EmberGen version in docs for consistency.

### DIFF
--- a/content/showcase/embergen.md
+++ b/content/showcase/embergen.md
@@ -47,7 +47,7 @@ We get it: simulations and renders usually take forever to get right. That's why
 ## EmberGen for Film & Motion Graphics
 
 <video width="100%" autoplay loop muted class="showcase-right"><source src="https://jangafx.com/Q12021Launch/Media_Organized/videos/EmberGen/Film/wargaming-01.mp4"></video>
-With the release of EmberGen 0.7.5, we're now a force to be reckoned with in the film industry. After adding animated FBX and Alembic support, as well as FBX camera imports and backplates, we guarantee you that EmberGen has a place in your pipeline. In the face of ever-tightening deadlines, studios around the world are turning to EmberGen. EmberGen can help you dramatically reduce time spent on simulations and rendering. Export to EXR/PNG/TGA and openVDB.
+With the release of EmberGen 1.0, we're now a force to be reckoned with in the film industry. After adding animated FBX and Alembic support, as well as FBX camera imports and backplates, we guarantee you that EmberGen has a place in your pipeline. In the face of ever-tightening deadlines, studios around the world are turning to EmberGen. EmberGen can help you dramatically reduce time spent on simulations and rendering. Export to EXR/PNG/TGA and openVDB.
 
 <div class="clearfix"></div>
 


### PR DESCRIPTION
Hey, I remember seeing a [release trailer](https://www.youtube.com/watch?v=EJgA0LLq5TM) for EmberGen version 1.0 in just the past few days on Discord.

However, I noticed that these docs here still mention the old 0.x version. 

Listing a 1.0 or up version seems likely to be more attractive to prospective customers and users, since many people avoid anything that isn't 1.0+.

Unless I don't fully understand the release schedule (etc), then I suspect it is time to change this version number here.